### PR TITLE
docs: Add comprehensive HTTP API and Apple Pay documentation

### DIFF
--- a/APPLE_PAY_DOCUMENTATION.md
+++ b/APPLE_PAY_DOCUMENTATION.md
@@ -1,0 +1,1473 @@
+# EdfaPg iOS SDK - Apple Pay Integration Documentation
+
+## Table of Contents
+- [Overview](#overview)
+- [Prerequisites](#prerequisites)
+- [Apple Pay Configuration](#apple-pay-configuration)
+- [Integration Steps](#integration-steps)
+- [API Flow](#api-flow)
+- [Request Structure](#request-structure)
+- [Response Structure](#response-structure)
+- [Code Examples](#code-examples)
+- [Payment Token Details](#payment-token-details)
+- [Error Handling](#error-handling)
+- [Testing](#testing)
+- [Best Practices](#best-practices)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+The EdfaPg iOS SDK provides seamless Apple Pay integration for processing secure payments through the Apple Pay framework. The SDK handles:
+
+- Apple Pay authorization flow
+- Payment token generation and encryption
+- Server-to-server (S2S) sale processing
+- 3D Secure authentication (if required)
+- Transaction completion and callbacks
+
+**Key Features:**
+- Native Apple Pay UI with minimal code
+- Automatic device capability detection
+- Support for all payment networks (Visa, Mastercard, Amex, etc.)
+- Customizable payment summary items
+- Shipping address collection (optional)
+- Transaction status callbacks
+- Debug logging for troubleshooting
+
+---
+
+## Prerequisites
+
+### 1. Apple Developer Account Requirements
+
+You must have:
+- Active Apple Developer account
+- Apple Pay merchant identifier
+- Payment Processing Certificate
+- Merchant Identity Certificate
+
+### 2. Xcode Configuration
+
+- Xcode 13.0 or later
+- iOS 11.0+ deployment target
+- Apple Pay capability enabled in project
+
+### 3. EdfaPg Account Setup
+
+- EdfaPg merchant account
+- Client Key (Merchant Key)
+- Client Password
+- Payment URL
+- Apple Pay enabled on your merchant account
+
+---
+
+## Apple Pay Configuration
+
+### Step 1: Create Apple Pay Merchant ID
+
+1. Go to [Apple Developer Portal](https://developer.apple.com/account/)
+2. Navigate to **Certificates, Identifiers & Profiles**
+3. Select **Identifiers** → **Merchant IDs**
+4. Click **+** to create new Merchant ID
+5. Choose **Merchant IDs** type
+6. Enter Description: "EdfaPay Payment Gateway"
+7. Enter Identifier: `merchant.com.yourcompany.applepay`
+8. Click **Continue** and **Register**
+
+### Step 2: Configure Xcode Project
+
+#### Enable Apple Pay Capability
+
+1. Open your Xcode project
+2. Select your target
+3. Go to **Signing & Capabilities** tab
+4. Click **+ Capability**
+5. Add **Apple Pay**
+6. Select your Merchant ID from the list
+
+![Apple Pay Configuration](https://github.com/user-attachments/assets/500b9b1b-2fa6-4da2-9db5-7a1a7baf13ff)
+
+#### Update Info.plist
+
+No additional Info.plist entries are required for Apple Pay, but ensure you have:
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <false/>
+</dict>
+```
+
+### Step 3: Import Required Frameworks
+
+```swift
+import PassKit
+import EdfaPgSdk
+```
+
+---
+
+## Integration Steps
+
+### Step 1: Initialize EdfaPg SDK
+
+Initialize the SDK in your `AppDelegate.swift`:
+
+```swift
+import UIKit
+import EdfaPgSdk
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    func application(_ application: UIApplication, 
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        // Initialize EdfaPg SDK
+        let credentials = EdfaPgCredential(
+            clientKey: "YOUR_MERCHANT_KEY",
+            clientPass: "YOUR_MERCHANT_PASSWORD",
+            paymentUrl: "https://pay.expresspay.sa/payment/post"
+        )
+        EdfaPgSdk.config(credentials)
+        
+        return true
+    }
+}
+```
+
+### Step 2: Prepare Order and Payer Data
+
+```swift
+// Create order
+let order = EdfaPgSaleOrder(
+    id: UUID().uuidString,
+    description: "Apple Pay Order",
+    currency: "SAR",  // Currency code
+    amount: 100.00,   // Amount in specified currency
+    country: "SA"     // Country code
+)
+
+// Create payer information
+let payer = EdfaPgPayer(
+    firstName: "John",
+    lastName: "Doe",
+    address: "123 Main Street",
+    country: "SA",
+    city: "Riyadh",
+    zip: "12345",
+    email: "john.doe@example.com",
+    phone: "+966500000000",
+    ip: "192.168.1.1"  // Customer's IP address
+)
+```
+
+### Step 3: Initialize Apple Pay
+
+```swift
+EdfaApplePay()
+    .set(order: order)
+    .set(payer: payer)
+    .set(applePayMerchantID: "merchant.com.yourcompany.applepay")
+    .enable(logs: true)  // Enable debug logging
+    .on(authentication: { payment in
+        // Called when user authorizes payment
+        print("Payment authorized")
+        if let paymentData = String(data: payment.token.paymentData, encoding: .utf8) {
+            print("Payment data: \(paymentData)")
+        }
+    })
+    .on(transactionSuccess: { response in
+        // Called when transaction completes successfully
+        print("Transaction successful!")
+        print("Response: \(response ?? [:])")
+    })
+    .on(transactionFailure: { response in
+        // Called when transaction fails
+        print("Transaction failed!")
+        print("Error: \(response)")
+    })
+    .initialize(
+        target: self,
+        onError: { errors in
+            // Called if Apple Pay cannot be initialized
+            print("Initialization error: \(errors)")
+        },
+        onPresent: {
+            // Called when Apple Pay sheet is presented
+            print("Apple Pay sheet presented")
+        }
+    )
+```
+
+---
+
+## API Flow
+
+### Complete Apple Pay Transaction Flow
+
+```
+┌─────────────────┐
+│   Your App      │
+└────────┬────────┘
+         │
+         │ 1. Initialize EdfaApplePay
+         ▼
+┌─────────────────┐
+│  EdfaApplePay   │
+│     Class       │
+└────────┬────────┘
+         │
+         │ 2. Check Apple Pay availability
+         │    PKPaymentAuthorizationViewController.canMakePayments()
+         ▼
+┌─────────────────┐
+│   Apple Pay     │
+│   Framework     │
+└────────┬────────┘
+         │
+         │ 3. Present Apple Pay sheet
+         │    User authorizes payment
+         ▼
+┌─────────────────┐
+│  PKPayment      │
+│    Object       │
+└────────┬────────┘
+         │
+         │ 4. Extract payment token
+         │    PKPaymentToken
+         ▼
+┌─────────────────┐
+│ EdfaPgVirtual   │
+│  SaleAdapter    │
+└────────┬────────┘
+         │
+         │ 5. Send S2S request
+         │    POST /applepay/orders/s2s/sale
+         ▼
+┌─────────────────┐
+│  EdfaPg Server  │
+└────────┬────────┘
+         │
+         │ 6. Process payment
+         │    Decrypt token, authorize
+         ▼
+┌─────────────────┐
+│    Response     │
+│  SUCCESS/FAIL   │
+└────────┬────────┘
+         │
+         │ 7. Return to app
+         ▼
+┌─────────────────┐
+│   Callbacks     │
+│   Triggered     │
+└─────────────────┘
+```
+
+### Detailed Step-by-Step Flow
+
+1. **Initialization Phase**
+   - App calls `EdfaApplePay().initialize()`
+   - SDK validates configuration (order, payer, merchant ID)
+   - SDK checks Apple Pay device capability
+   - Creates `PKPaymentRequest` object
+
+2. **Payment Authorization Phase**
+   - SDK presents `PKPaymentAuthorizationViewController`
+   - User authenticates with Face ID/Touch ID
+   - User confirms payment amount and details
+   - Apple Pay generates encrypted payment token
+
+3. **Token Extraction Phase**
+   - SDK receives `PKPayment` object
+   - Extracts `PKPaymentToken` with encrypted data
+   - Extracts payment method details (network, type)
+   - Calls `onAuthentication` callback (optional)
+
+4. **Server Communication Phase**
+   - SDK constructs multipart request
+   - Includes payment token as JSON string
+   - Calculates security hash
+   - Sends POST to `/applepay/orders/s2s/sale`
+
+5. **Processing Phase**
+   - EdfaPg server receives request
+   - Decrypts Apple Pay token
+   - Processes payment through card network
+   - Returns transaction result
+
+6. **Completion Phase**
+   - SDK receives response
+   - Calls `onTransactionSuccess` or `onTransactionFailure`
+   - Dismisses Apple Pay sheet
+   - Updates transaction status in UI
+
+---
+
+## Request Structure
+
+### HTTP Request Details
+
+**Endpoint**: `{baseUrl}/applepay/orders/s2s/sale`
+
+Where `baseUrl` is derived from payment URL:
+- Input: `https://pay.expresspay.sa/payment/post`
+- Base: `https://pay.expresspay.sa`
+- Endpoint: `https://pay.expresspay.sa/applepay/orders/s2s/sale`
+
+**Method**: POST
+
+**Content-Type**: `multipart/form-data; boundary=boundary-edfapay-pg-formdata`
+
+**Headers**:
+```
+X-User-Agent: ios
+Accept: application/json
+Content-Type: multipart/form-data; boundary=boundary-edfapay-pg-formdata
+```
+
+### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "SALE" |
+| `client_key` | String | Yes | Your EdfaPg merchant key |
+| `order_id` | String | Yes | Unique order identifier (UUID recommended) |
+| `order_amount` | String | Yes | Amount in format "XXX.XX" |
+| `order_currency` | String | Yes | ISO currency code (e.g., "SAR", "USD") |
+| `order_description` | String | Yes | Description of the order |
+| `payer_first_name` | String | Yes | Customer's first name |
+| `payer_last_name` | String | Yes | Customer's last name |
+| `payer_middle_name` | String | No | Customer's middle name |
+| `payer_birth_date` | String | No | Birth date (YYYY-MM-DD) |
+| `payer_address` | String | Yes | Billing address |
+| `payer_address2` | String | No | Additional address line |
+| `payer_country` | String | Yes | Country code (e.g., "SA") |
+| `payer_state` | String | No | State/region |
+| `payer_city` | String | Yes | City name |
+| `payer_zip` | String | Yes | ZIP/postal code |
+| `payer_email` | String | Yes | Email address |
+| `payer_phone` | String | Yes | Phone number |
+| `payer_ip` | String | Yes | Customer's IP address |
+| `brand` | String | Yes | Always "applepay" |
+| `identifier` | String | Yes | Apple Pay transaction identifier |
+| `return_url` | String | Yes | Callback URL after processing |
+| `parameters` | String | Yes | JSON string with payment token data |
+| `hash` | String | Yes | Security hash for request validation |
+
+### Hash Calculation
+
+The hash is calculated using the following formula:
+
+```
+md5(
+  strtoupper(
+    strrev(identifier) + 
+    client_password + 
+    order_number + 
+    order_amount + 
+    order_currency
+  )
+)
+```
+
+**Swift Implementation**:
+```swift
+let hash = EdfaPgHashUtil.hashApplePayVirtual(
+    identifier: applePayTransactionIdentifier,
+    number: order.id,
+    amount: order.formatedAmountString(),  // "100.00"
+    currency: order.currency                // "SAR"
+)
+```
+
+**Example Calculation**:
+```swift
+// Given:
+let identifier = "ABC123XYZ"
+let clientPassword = "MySecret123"
+let orderNumber = "order-12345"
+let amount = "100.00"
+let currency = "SAR"
+
+// Step 1: Reverse identifier
+let idRev = "ZYXABC321"
+
+// Step 2: Concatenate
+let str = "ZYXABC321MySecret123order-12345100.00SAR"
+
+// Step 3: Uppercase
+let upper = "ZYXABC321MYSECRET123ORDER-12345100.00SAR"
+
+// Step 4: MD5 hash
+let hash = md5(upper)  // "a1b2c3d4e5f6..."
+```
+
+### Payment Token (parameters field)
+
+The `parameters` field contains a JSON string with the Apple Pay token:
+
+```json
+{
+  "paymentData": {
+    "version": "EC_v1",
+    "data": "base64-encoded-encrypted-payment-data",
+    "signature": "base64-encoded-signature",
+    "header": {
+      "ephemeralPublicKey": "base64-encoded-public-key",
+      "publicKeyHash": "base64-encoded-hash",
+      "transactionId": "unique-transaction-identifier"
+    }
+  },
+  "paymentMethod": {
+    "displayName": "Visa 1234",
+    "network": "Visa",
+    "type": "debit"
+  },
+  "transactionIdentifier": "unique-apple-pay-transaction-id"
+}
+```
+
+### Sample Request
+
+**Raw HTTP Request**:
+```http
+POST /applepay/orders/s2s/sale HTTP/1.1
+Host: pay.expresspay.sa
+X-User-Agent: ios
+Accept: application/json
+Content-Type: multipart/form-data; boundary=boundary-edfapay-pg-formdata
+
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="action"
+
+SALE
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="client_key"
+
+58e9490c-000c-11ed-000-76632760000
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="order_id"
+
+order-abc-123-xyz
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="order_amount"
+
+100.00
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="order_currency"
+
+SAR
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="order_description"
+
+Apple Pay Payment
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_first_name"
+
+John
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_last_name"
+
+Doe
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_email"
+
+john.doe@example.com
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_phone"
+
++966500000000
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_address"
+
+123 Main Street
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_country"
+
+SA
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_city"
+
+Riyadh
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_zip"
+
+12345
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="payer_ip"
+
+192.168.1.1
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="brand"
+
+applepay
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="identifier"
+
+ABC123XYZ789
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="return_url"
+
+https://yourapp.com/callback
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="parameters"
+
+{"paymentData":{"version":"EC_v1","data":"..."},"paymentMethod":{"displayName":"Visa 1234","network":"Visa","type":"debit"},"transactionIdentifier":"ABC123XYZ789"}
+--boundary-edfapay-pg-formdata
+Content-Disposition: form-data; name="hash"
+
+a1b2c3d4e5f6g7h8i9j0
+--boundary-edfapay-pg-formdata--
+```
+
+---
+
+## Response Structure
+
+### Success Response
+
+**HTTP Status**: 200 OK
+
+**Response Object**: `EdfaPgSaleVirtualTransaction`
+
+```json
+{
+  "action": "SALE",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-abc-123-xyz",
+  "trans_id": "3f8c2a1e-9b7d-4c6e-a5f3-1234567890ab",
+  "trans_date": "2024-01-15 14:30:45",
+  "descriptor": "EdfaPay Merchant",
+  "amount": "100.00",
+  "currency": "SAR"
+}
+```
+
+**Response Fields**:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `action` | String | Always "SALE" |
+| `result` | String | "SUCCESS" for successful transactions |
+| `status` | String | Transaction status ("SETTLED", "PENDING", etc.) |
+| `order_id` | String | Your original order identifier |
+| `trans_id` | String | EdfaPg transaction ID (UUID) |
+| `trans_date` | String | Transaction timestamp |
+| `descriptor` | String | Merchant name shown on statement |
+| `amount` | String | Transaction amount |
+| `currency` | String | Currency code |
+
+### Error Response
+
+**HTTP Status**: 200 OK (errors are in response body)
+
+```json
+{
+  "result": "ERROR",
+  "error_code": 1001,
+  "error_message": "Invalid payment token",
+  "errors": {
+    "payment_token": ["Payment token is invalid or expired"]
+  }
+}
+```
+
+### Decline Response
+
+```json
+{
+  "action": "SALE",
+  "result": "DECLINED",
+  "status": "DECLINED",
+  "order_id": "order-abc-123-xyz",
+  "trans_id": "3f8c2a1e-9b7d-4c6e-a5f3-1234567890ab",
+  "trans_date": "2024-01-15 14:30:45",
+  "decline_reason": "Insufficient funds"
+}
+```
+
+---
+
+## Code Examples
+
+### Basic Apple Pay Integration
+
+```swift
+import UIKit
+import PassKit
+import EdfaPgSdk
+
+class CheckoutViewController: UIViewController {
+    
+    // Apple Pay merchant ID from Apple Developer Portal
+    let applePayMerchantID = "merchant.com.yourcompany.applepay"
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupApplePayButton()
+    }
+    
+    func setupApplePayButton() {
+        // Create Apple Pay button
+        let applePayButton = PKPaymentButton(
+            paymentButtonType: .buy,
+            paymentButtonStyle: .black
+        )
+        applePayButton.addTarget(
+            self,
+            action: #selector(handleApplePayButtonTapped),
+            for: .touchUpInside
+        )
+        
+        // Add to view
+        applePayButton.frame = CGRect(x: 20, y: 200, width: view.frame.width - 40, height: 50)
+        view.addSubview(applePayButton)
+    }
+    
+    @objc func handleApplePayButtonTapped() {
+        initiateApplePayment()
+    }
+    
+    func initiateApplePayment() {
+        // Prepare order
+        let order = EdfaPgSaleOrder(
+            id: UUID().uuidString,
+            description: "Premium Subscription",
+            currency: "SAR",
+            amount: 99.99,
+            country: "SA"
+        )
+        
+        // Prepare payer info
+        let payer = EdfaPgPayer(
+            firstName: "John",
+            lastName: "Doe",
+            address: "123 Main Street",
+            country: "SA",
+            city: "Riyadh",
+            zip: "12345",
+            email: "john.doe@example.com",
+            phone: "+966500000000",
+            ip: getDeviceIP()
+        )
+        
+        // Initialize Apple Pay
+        EdfaApplePay()
+            .set(order: order)
+            .set(payer: payer)
+            .set(applePayMerchantID: applePayMerchantID)
+            .enable(logs: true)
+            .on(authentication: { [weak self] payment in
+                self?.handleAuthentication(payment)
+            })
+            .on(transactionSuccess: { [weak self] response in
+                self?.handleTransactionSuccess(response)
+            })
+            .on(transactionFailure: { [weak self] response in
+                self?.handleTransactionFailure(response)
+            })
+            .initialize(
+                target: self,
+                onError: { [weak self] errors in
+                    self?.handleInitializationError(errors)
+                },
+                onPresent: {
+                    print("Apple Pay sheet presented")
+                }
+            )
+    }
+    
+    func handleAuthentication(_ payment: PKPayment) {
+        print("✅ Payment authorized")
+        print("Transaction ID: \(payment.token.transactionIdentifier)")
+        print("Payment method: \(payment.token.paymentMethod.displayName ?? "Unknown")")
+    }
+    
+    func handleTransactionSuccess(_ response: [String: Any]?) {
+        guard let response = response else { return }
+        
+        print("✅ Transaction successful!")
+        
+        if let transactionId = response["trans_id"] as? String {
+            print("Transaction ID: \(transactionId)")
+        }
+        
+        if let amount = response["amount"] as? String,
+           let currency = response["currency"] as? String {
+            print("Amount: \(amount) \(currency)")
+        }
+        
+        // Show success UI
+        showSuccessAlert(message: "Payment successful!")
+    }
+    
+    func handleTransactionFailure(_ response: [String: Any]) {
+        print("❌ Transaction failed")
+        
+        let errorMessage = response["error"] as? String 
+            ?? response["decline_reason"] as? String 
+            ?? "Payment failed"
+        
+        print("Error: \(errorMessage)")
+        
+        // Show error UI
+        showErrorAlert(message: errorMessage)
+    }
+    
+    func handleInitializationError(_ errors: Any) {
+        print("❌ Apple Pay initialization failed")
+        print("Errors: \(errors)")
+        
+        if let errorArray = errors as? [String] {
+            let message = errorArray.joined(separator: "\n")
+            showErrorAlert(message: message)
+        } else {
+            showErrorAlert(message: "Unable to initialize Apple Pay")
+        }
+    }
+    
+    // Helper methods
+    func getDeviceIP() -> String {
+        // Implement IP detection
+        // For production, fetch from your backend
+        return "192.168.1.1"
+    }
+    
+    func showSuccessAlert(message: String) {
+        let alert = UIAlertController(
+            title: "Success",
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+    
+    func showErrorAlert(message: String) {
+        let alert = UIAlertController(
+            title: "Error",
+            message: message,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+```
+
+### Advanced Configuration
+
+#### Custom Payment Summary Items
+
+```swift
+EdfaApplePay()
+    .set(order: order)
+    .set(payer: payer)
+    .set(applePayMerchantID: applePayMerchantID)
+    // Add custom line items
+    .addPurchaseItem(
+        label: "Subtotal",
+        amount: 89.99,
+        type: .final
+    )
+    .addPurchaseItem(
+        label: "Tax",
+        amount: 10.00,
+        type: .final
+    )
+    .addPurchaseItem(
+        label: "Total",
+        amount: 99.99,
+        type: .final
+    )
+    .initialize(target: self, onError: { _ in }, onPresent: nil)
+```
+
+#### Specific Payment Networks
+
+```swift
+import PassKit
+
+EdfaApplePay()
+    .set(order: order)
+    .set(payer: payer)
+    .set(applePayMerchantID: applePayMerchantID)
+    // Restrict to specific networks
+    .addSupported(paymentNetworks: [
+        .visa,
+        .masterCard,
+        .amex
+    ])
+    .initialize(target: self, onError: { _ in }, onPresent: nil)
+```
+
+#### Custom Merchant Capabilities
+
+```swift
+EdfaApplePay()
+    .set(order: order)
+    .set(payer: payer)
+    .set(applePayMerchantID: applePayMerchantID)
+    // Set merchant capabilities
+    .set(merchantCapability: [.capability3DS, .capabilityEMV])
+    .initialize(target: self, onError: { _ in }, onPresent: nil)
+```
+
+#### Collect Shipping Address
+
+```swift
+let shippingAddress = EdfaPgShippingAddress(
+    name: "John Doe",
+    address: "123 Main St, Riyadh, SA",
+    email: "john.doe@example.com",
+    phone: "+966500000000"
+)
+
+EdfaApplePay()
+    .set(order: order)
+    .set(payer: payer)
+    .set(applePayMerchantID: applePayMerchantID)
+    .set(shippingAddress: shippingAddress)
+    .initialize(target: self, onError: { _ in }, onPresent: nil)
+```
+
+---
+
+## Payment Token Details
+
+### PKPayment Object Structure
+
+When Apple Pay authorization succeeds, you receive a `PKPayment` object:
+
+```swift
+public class PKPayment {
+    var token: PKPaymentToken          // Encrypted payment data
+    var billingContact: PKContact?     // Billing address
+    var shippingContact: PKContact?    // Shipping address
+    var shippingMethod: PKShippingMethod?
+}
+```
+
+### PKPaymentToken Structure
+
+```swift
+public class PKPaymentToken {
+    var paymentMethod: PKPaymentMethod  // Card details
+    var paymentData: Data               // Encrypted payment data
+    var transactionIdentifier: String   // Unique transaction ID
+}
+```
+
+### PKPaymentMethod Structure
+
+```swift
+public class PKPaymentMethod {
+    var displayName: String?     // e.g., "Visa 1234"
+    var network: PKPaymentNetwork?  // e.g., .visa
+    var type: PKPaymentMethodType   // .debit, .credit, .prepaid
+}
+```
+
+### Encrypted Payment Data
+
+The `paymentData` field contains encrypted card information in PKPayment token format:
+
+```json
+{
+  "version": "EC_v1",
+  "data": "encrypted-payment-data-base64",
+  "signature": "signature-base64",
+  "header": {
+    "ephemeralPublicKey": "ephemeral-key-base64",
+    "publicKeyHash": "key-hash-base64",
+    "transactionId": "transaction-identifier"
+  }
+}
+```
+
+**Important**: This data is encrypted by Apple and can only be decrypted by EdfaPg servers using the merchant's payment processing certificate.
+
+### Payment Token Extraction
+
+The SDK automatically extracts and formats the payment token:
+
+```swift
+// Inside EdfaApplePay implementation
+let token = payment.token
+let method = payment.token.paymentMethod
+
+if let paymentDataJSON = try? JSONSerialization.jsonObject(
+    with: token.paymentData
+) as? [String: Any] {
+    let paymentJSON: [String: Any] = [
+        "paymentData": paymentDataJSON,
+        "paymentMethod": [
+            "displayName": method.displayName ?? "",
+            "network": method.network?.rawValue ?? "",
+            "type": method.type.name()
+        ],
+        "transactionIdentifier": token.transactionIdentifier
+    ]
+    
+    // Convert to JSON string
+    let paymentToken = try? JSONSerialization.data(withJSONObject: paymentJSON)
+    let paymentTokenString = String(data: paymentToken!, encoding: .utf8)
+}
+```
+
+---
+
+## Error Handling
+
+### Common Error Scenarios
+
+#### 1. Apple Pay Not Supported
+
+**Error**: Device doesn't support Apple Pay
+
+```swift
+.initialize(
+    target: self,
+    onError: { errors in
+        // errors contains: 
+        // ["Cannot start apple pay, device may not supported or user/merchant is restricted from authorizing payments"]
+    },
+    onPresent: nil
+)
+```
+
+**Solution**:
+- Check device capability before showing Apple Pay button
+- Provide alternative payment methods
+
+```swift
+func isApplePayAvailable() -> Bool {
+    return PKPaymentAuthorizationViewController.canMakePayments()
+}
+
+// Check specific networks
+func canUseApplePayWithCards() -> Bool {
+    return PKPaymentAuthorizationViewController.canMakePayments(
+        usingNetworks: [.visa, .masterCard]
+    )
+}
+```
+
+#### 2. No Cards Configured
+
+**Error**: User hasn't added cards to Apple Wallet
+
+```swift
+if !PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: supportedNetworks) {
+    // Show "Set up Apple Pay" button
+    showSetupApplePayButton()
+}
+```
+
+#### 3. Invalid Merchant ID
+
+**Error**: Merchant ID not configured correctly
+
+```swift
+.initialize(
+    target: self,
+    onError: { errors in
+        // errors contains:
+        // ["Missing or invalid apple pay 'merchant identifier'"]
+    },
+    onPresent: nil
+)
+```
+
+**Solution**:
+- Verify merchant ID in Apple Developer Portal
+- Ensure merchant ID is added to Xcode capabilities
+- Check merchant ID matches exactly
+
+#### 4. Invalid Amount
+
+**Error**: Amount less than minimum (0.10)
+
+```swift
+.initialize(
+    target: self,
+    onError: { errors in
+        // errors contains:
+        // ["Missing or invalid amount should be greater than 0.09"]
+    },
+    onPresent: nil
+)
+```
+
+**Solution**:
+```swift
+// Validate amount before initialization
+guard order.amount >= 0.10 else {
+    print("Amount must be at least 0.10")
+    return
+}
+```
+
+#### 5. Missing Required Callbacks
+
+**Error**: Transaction callbacks not set
+
+```swift
+.initialize(
+    target: self,
+    onError: { errors in
+        // errors contains:
+        // ["onTransactionSuccess not set, try to call function 'EdfaApplePay.on(transactionSuccess:)'"]
+    },
+    onPresent: nil
+)
+```
+
+**Solution**:
+```swift
+// Always set both success and failure callbacks
+EdfaApplePay()
+    .on(transactionSuccess: { response in
+        // Handle success
+    })
+    .on(transactionFailure: { response in
+        // Handle failure
+    })
+    .initialize(target: self, onError: { _ in }, onPresent: nil)
+```
+
+#### 6. User Cancellation
+
+**Scenario**: User cancels Apple Pay sheet
+
+```swift
+// Apple Pay sheet is automatically dismissed
+// No callback is triggered
+// Simply return user to previous screen
+```
+
+#### 7. Network/Server Errors
+
+**Error**: Request to EdfaPg server fails
+
+```swift
+.on(transactionFailure: { response in
+    if let error = response["error"] as? String {
+        if error.contains("Error while performing purchase") {
+            // Network error or server unavailable
+            print("Please check your connection and try again")
+        }
+    }
+})
+```
+
+### Validation Before Initialization
+
+```swift
+func validateApplePayConfiguration() -> (valid: Bool, errors: [String]) {
+    var errors: [String] = []
+    
+    // Check device support
+    if !PKPaymentAuthorizationViewController.canMakePayments() {
+        errors.append("Apple Pay is not available on this device")
+    }
+    
+    // Check amount
+    if order.amount < 0.10 {
+        errors.append("Amount must be at least 0.10")
+    }
+    
+    // Check currency
+    if order.currency.isEmpty {
+        errors.append("Currency code is required")
+    }
+    
+    // Check country
+    if order.country.isEmpty {
+        errors.append("Country code is required")
+    }
+    
+    // Check merchant ID
+    if applePayMerchantID.isEmpty {
+        errors.append("Apple Pay Merchant ID is required")
+    }
+    
+    return (errors.isEmpty, errors)
+}
+
+// Use before initialization
+let validation = validateApplePayConfiguration()
+if !validation.valid {
+    showErrors(validation.errors)
+    return
+}
+
+// Proceed with initialization
+initiateApplePayment()
+```
+
+---
+
+## Testing
+
+### Test Environment Setup
+
+1. **Use Sandbox Account**
+   - Sign in with sandbox Apple ID in Settings → Wallet & Apple Pay
+   - Add test cards provided by Apple
+
+2. **Test Cards**
+   - Visa: 4761 1200 1000 0492
+   - Mastercard: 5204 2477 5000 1471
+   - Amex: 3782 822463 10005
+
+3. **Simulator Testing**
+   - Open Simulator
+   - Go to Features → Wallet → Add Card
+   - Enter test card details
+
+### Test Scenarios
+
+#### Successful Payment
+```swift
+// Expected flow:
+// 1. Apple Pay sheet appears
+// 2. User authenticates
+// 3. onAuthentication callback triggered
+// 4. Server processes payment
+// 5. onTransactionSuccess callback triggered
+// 6. Apple Pay sheet dismisses
+```
+
+#### Declined Payment
+```swift
+// Test with declined test card
+// Expected: onTransactionFailure with decline_reason
+```
+
+#### User Cancellation
+```swift
+// User taps Cancel on Apple Pay sheet
+// Expected: Sheet dismisses, no callbacks
+```
+
+#### Network Failure
+```swift
+// Disable network connection
+// Expected: onTransactionFailure with network error
+```
+
+### Debug Logging
+
+Enable detailed logging:
+
+```swift
+EdfaApplePay()
+    .enable(logs: true)  // Enables debug output
+    .initialize(target: self, onError: { _ in }, onPresent: nil)
+```
+
+Debug output includes:
+- Request URL and parameters
+- Payment token data
+- Server response
+- Error messages
+
+Example output:
+```
+-------------------------------------------------------------
+POST
+REQUEST:
+  URL: 
+    https://pay.expresspay.sa/applepay/orders/s2s/sale
+  HEADERS: 
+    {
+      "Accept": "application/json",
+      "Content-Type": "multipart/form-data",
+      "X-User-Agent": "ios"
+    }
+  PARAMETERS:
+    action: SALE
+    client_key: merchant-key
+    order_id: order-123
+    ...
+RESPONSE:
+  {
+    "result": "SUCCESS",
+    "status": "SETTLED",
+    ...
+  }
+-------------------------------------------------------------
+```
+
+---
+
+## Best Practices
+
+### 1. Device Capability Check
+
+Always check if Apple Pay is available before showing the button:
+
+```swift
+override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    if PKPaymentAuthorizationViewController.canMakePayments() {
+        setupApplePayButton()
+    } else {
+        showAlternativePaymentMethods()
+    }
+}
+```
+
+### 2. User Experience
+
+- Show Apple Pay button only when available
+- Use standard PKPaymentButton for consistency
+- Handle all callback scenarios gracefully
+- Provide clear error messages
+
+```swift
+// Use standard Apple Pay button
+let button = PKPaymentButton(
+    paymentButtonType: .buy,    // or .donate, .checkout
+    paymentButtonStyle: .black   // or .white, .whiteOutline
+)
+```
+
+### 3. Security
+
+- Never log payment tokens in production
+- Use HTTPS for all API calls
+- Validate amounts on server side
+- Implement proper error handling
+
+```swift
+#if DEBUG
+    .enable(logs: true)
+#else
+    .enable(logs: false)
+#endif
+```
+
+### 4. Amount Formatting
+
+Always format amounts correctly:
+
+```swift
+// Use order.formatedAmountString() for consistency
+let amount = order.formatedAmountString()  // "100.00"
+```
+
+### 5. Callback Retention
+
+Avoid retain cycles in callbacks:
+
+```swift
+EdfaApplePay()
+    .on(transactionSuccess: { [weak self] response in
+        self?.handleSuccess(response)
+    })
+    .on(transactionFailure: { [weak self] response in
+        self?.handleFailure(response)
+    })
+```
+
+### 6. Error Communication
+
+Provide user-friendly error messages:
+
+```swift
+func getUserFriendlyError(_ error: String) -> String {
+    switch error {
+    case let e where e.contains("Invalid payment token"):
+        return "Payment authorization failed. Please try again."
+    case let e where e.contains("Insufficient funds"):
+        return "Insufficient funds. Please use another card."
+    case let e where e.contains("network"):
+        return "Network error. Please check your connection."
+    default:
+        return "Payment failed. Please try again or use another payment method."
+    }
+}
+```
+
+### 7. Transaction Tracking
+
+Store transaction IDs for reference:
+
+```swift
+func handleTransactionSuccess(_ response: [String: Any]?) {
+    guard let transactionId = response?["trans_id"] as? String else { return }
+    
+    // Store for later reference
+    UserDefaults.standard.set(transactionId, forKey: "lastTransactionId")
+    
+    // Or save to your backend
+    saveTransactionToBackend(transactionId)
+}
+```
+
+### 8. Timeout Handling
+
+Implement timeout for long-running requests:
+
+```swift
+// Set a timeout for the payment process
+DispatchQueue.main.asyncAfter(deadline: .now() + 30.0) { [weak self] in
+    if !self.paymentCompleted {
+        self?.handleTimeout()
+    }
+}
+```
+
+---
+
+## Troubleshooting
+
+### Issue: Apple Pay Button Not Appearing
+
+**Possible Causes**:
+1. Device doesn't support Apple Pay
+2. No cards in Wallet
+3. Merchant ID not configured
+
+**Solutions**:
+```swift
+// Check support
+print("Can make payments: \(PKPaymentAuthorizationViewController.canMakePayments())")
+
+// Check with networks
+let networks: [PKPaymentNetwork] = [.visa, .masterCard]
+print("Can make payments with cards: \(PKPaymentAuthorizationViewController.canMakePayments(usingNetworks: networks))")
+
+// Verify merchant ID in capabilities tab
+```
+
+### Issue: Payment Authorization Fails Immediately
+
+**Possible Causes**:
+1. Invalid merchant ID
+2. Missing certificates
+3. Merchant ID not approved by Apple
+
+**Solutions**:
+1. Verify merchant ID in Apple Developer Portal
+2. Check payment processing certificate
+3. Wait for Apple approval (can take 24-48 hours)
+
+### Issue: Transaction Always Fails
+
+**Possible Causes**:
+1. Invalid credentials
+2. Incorrect hash calculation
+3. Server configuration
+
+**Solutions**:
+```swift
+// Enable debug logging
+.enable(logs: true)
+
+// Check credentials
+print("Client Key: \(EdfaPgSdk.shared.credentials.clientKey)")
+print("Payment URL: \(EdfaPgSdk.shared.credentials.paymentUrl)")
+
+// Verify hash
+let hash = EdfaPgHashUtil.hashApplePayVirtual(...)
+print("Calculated Hash: \(hash)")
+```
+
+### Issue: "Cannot start apple pay" Error
+
+**Possible Causes**:
+1. Device restrictions
+2. Region restrictions
+3. Parental controls
+
+**Solutions**:
+- Test on different device
+- Check Settings → Wallet & Apple Pay
+- Verify region settings
+
+### Issue: Payment Token Invalid
+
+**Possible Causes**:
+1. Token expired
+2. Malformed token data
+3. Certificate mismatch
+
+**Solutions**:
+- Process payment immediately after authorization
+- Check token structure in logs
+- Verify certificate configuration with EdfaPg support
+
+### Getting Help
+
+If issues persist:
+
+1. **Enable Debug Logging**:
+   ```swift
+   .enable(logs: true)
+   ```
+
+2. **Collect Information**:
+   - iOS version
+   - Device model
+   - Error messages
+   - Request/response logs
+
+3. **Contact Support**:
+   - Email: support@edfapay.com
+   - Phone: +966920033633
+   - Include transaction ID and timestamp
+
+---
+
+## Additional Resources
+
+### Apple Documentation
+- [Apple Pay Programming Guide](https://developer.apple.com/documentation/passkit/apple_pay)
+- [PKPaymentAuthorizationViewController](https://developer.apple.com/documentation/passkit/pkpaymentauthorizationviewcontroller)
+- [Apple Pay Sandbox Testing](https://developer.apple.com/apple-pay/sandbox-testing/)
+
+### EdfaPg Resources
+- Website: [https://edfapay.com](https://edfapay.com)
+- Support Email: [support@edfapay.com](mailto:support@edfapay.com)
+- Phone: [+966920033633](tel:+966920033633)
+
+### Related Documentation
+- [HTTP_API_DOCUMENTATION.md](./HTTP_API_DOCUMENTATION.md) - Complete API reference
+- [README.md](./README.md) - SDK overview and basic usage
+
+---
+
+## Summary Checklist
+
+Before going live with Apple Pay:
+
+- [ ] Apple Pay Merchant ID created
+- [ ] Payment Processing Certificate configured
+- [ ] Merchant ID added to Xcode capabilities
+- [ ] SDK initialized with correct credentials
+- [ ] Apple Pay tested in sandbox
+- [ ] Success callback implemented
+- [ ] Failure callback implemented
+- [ ] Error handling implemented
+- [ ] User-friendly messages configured
+- [ ] Transaction logging added
+- [ ] Production certificates installed
+- [ ] Live testing completed
+- [ ] Support contact information added
+
+---
+
+*Last Updated: January 2025*
+*SDK Version: Compatible with EdfaPgSdk v1.x*
+*Apple Pay Version: iOS 11.0+*

--- a/APPLE_PAY_DOCUMENTATION.md
+++ b/APPLE_PAY_DOCUMENTATION.md
@@ -367,11 +367,13 @@ The hash is calculated using the following formula:
 ```
 md5(
   strtoupper(
-    strrev(identifier) + 
-    client_password + 
-    order_number + 
-    order_amount + 
-    order_currency
+    strrev(
+      identifier + 
+      order_number + 
+      order_amount + 
+      order_currency + 
+      client_password
+    )
   )
 )
 ```
@@ -390,19 +392,22 @@ let hash = EdfaPgHashUtil.hashApplePayVirtual(
 ```swift
 // Given:
 let identifier = "ABC123XYZ"
-let clientPassword = "MySecret123"
 let orderNumber = "order-12345"
 let amount = "100.00"
 let currency = "SAR"
+let clientPassword = "MySecret123"
 
-// Step 1: Reverse identifier
-let idRev = "ZYXABC321"
+// Step 1: Concatenate all values
+let combined = identifier + orderNumber + amount + currency + clientPassword
+// "ABC123XYZorder-12345100.00SARMySecret123"
 
-// Step 2: Concatenate
-let str = "ZYXABC321MySecret123order-12345100.00SAR"
+// Step 2: Reverse the entire combined string
+let reversed = String(combined.reversed())
+// "321terceSyMRAS00.00154321-redrOZYX321CBA"
 
 // Step 3: Uppercase
-let upper = "ZYXABC321MYSECRET123ORDER-12345100.00SAR"
+let upper = reversed.uppercased()
+// "321TERCESMYRAS00.00154321-REDRОЗYX321CBA"
 
 // Step 4: MD5 hash
 let hash = md5(upper)  // "a1b2c3d4e5f6..."

--- a/HTTP_API_DOCUMENTATION.md
+++ b/HTTP_API_DOCUMENTATION.md
@@ -1,0 +1,1231 @@
+# EdfaPg iOS SDK - HTTP API Documentation
+
+## Table of Contents
+- [Overview](#overview)
+- [Authentication](#authentication)
+- [Base Configuration](#base-configuration)
+- [API Endpoints](#api-endpoints)
+  - [SALE Transaction](#1-sale-transaction)
+  - [CAPTURE Transaction](#2-capture-transaction)
+  - [CREDITVOID Transaction](#3-creditvoid-transaction)
+  - [RECURRING_SALE Transaction](#4-recurring_sale-transaction)
+  - [GET_TRANS_STATUS](#5-get_trans_status)
+  - [GET_TRANS_DETAILS](#6-get_trans_details)
+  - [Apple Pay Virtual Sale](#7-apple-pay-virtual-sale)
+- [Response Structures](#response-structures)
+- [Error Handling](#error-handling)
+- [Hash Calculation](#hash-calculation)
+
+---
+
+## Overview
+
+The EdfaPg iOS SDK communicates with the EdfaPg Payment Platform through HTTP POST requests. All requests use one of two content types:
+- `application/x-www-form-urlencoded` - For standard payment operations
+- `multipart/form-data` - For Apple Pay virtual transactions
+
+All requests include custom headers:
+- `X-User-Agent: ios`
+- `Accept: application/json`
+
+---
+
+## Authentication
+
+All API requests require authentication using:
+1. **Client Key** (`client_key`) - Your merchant identifier
+2. **Client Password** - Used for hash generation (not sent directly)
+3. **Hash** - A cryptographic signature to validate requests
+
+### SDK Initialization
+
+```swift
+let edfaPgCredential = EdfaPgCredential(
+    clientKey: "YOUR_MERCHANT_KEY",
+    clientPass: "YOUR_MERCHANT_PASSWORD",
+    paymentUrl: "PAYMENT_URL"
+)
+EdfaPgSdk.config(edfaPgCredential)
+```
+
+---
+
+## Base Configuration
+
+**Base URL**: Configured via `paymentUrl` in credentials (e.g., `https://pay.expresspay.sa/payment/post`)
+
+**HTTP Method**: POST for all endpoints
+
+**Request Format**: URL-encoded form data or multipart form data
+
+**Response Format**: JSON
+
+---
+
+## API Endpoints
+
+### 1. SALE Transaction
+
+**Purpose**: Authorize and capture payment in a single transaction (Single Message System - SMS). Can also be used for AUTH-only transactions.
+
+**Endpoint**: `{paymentUrl}` (Base URL from configuration)
+
+**Content-Type**: `application/x-www-form-urlencoded`
+
+**Adapter Class**: `EdfaPgSaleAdapter`
+
+**Service Class**: `EdfaPgSaleService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "SALE" |
+| `client_key` | String | Yes | Merchant identifier |
+| `channel_id` | String | No | Sub-account identifier for specific channel |
+| `order_id` | String | Yes | Unique order identifier |
+| `order_amount` | String | Yes | Transaction amount (format: XXXX.XX) |
+| `order_currency` | String | Yes | Currency code (e.g., "SAR", "USD") |
+| `order_description` | String | Yes | Order description |
+| `card_number` | String | Yes | Credit card number |
+| `card_exp_month` | String | Yes | Card expiration month (format: MM) |
+| `card_exp_year` | String | Yes | Card expiration year (format: YYYY) |
+| `card_cvv2` | String | Yes | Card CVV/CVV2 code |
+| `payer_first_name` | String | Yes | Payer's first name |
+| `payer_last_name` | String | Yes | Payer's last name |
+| `payer_middle_name` | String | No | Payer's middle name |
+| `payer_birth_date` | String | No | Payer's birth date (format: YYYY-MM-DD) |
+| `payer_address` | String | Yes | Payer's address |
+| `payer_address2` | String | No | Additional address line |
+| `payer_country` | String | Yes | Payer's country code (2 letters, e.g., "SA") |
+| `payer_state` | String | No | Payer's state/region |
+| `payer_city` | String | Yes | Payer's city |
+| `payer_zip` | String | Yes | Payer's ZIP/postal code |
+| `payer_email` | String | Yes | Payer's email (max 256 chars) |
+| `payer_phone` | String | Yes | Payer's phone number |
+| `payer_ip` | String | Yes | Payer's IP address |
+| `term_url_3ds` | String | Yes | Return URL after 3D Secure (max 1024 chars) |
+| `recurring_init` | String | No | "Y" to initialize recurring payments |
+| `auth` | String | No | "Y" for AUTH-only (hold funds), omit for SALE (capture) |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+| `req_token` | String | Yes | Always "N" |
+
+#### Hash Calculation for SALE
+
+```swift
+let hash = EdfaPgHashUtil.hash(
+    email: payer.email,
+    cardNumber: card.number
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(email).client_password.strrev(substr(card_number, 0, 6).substr(card_number, -4))))`
+
+#### Sample Request (cURL)
+
+```bash
+curl -X POST https://pay.expresspay.sa/payment/post \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -d "action=SALE" \
+  -d "client_key=YOUR_MERCHANT_KEY" \
+  -d "order_id=order-12345" \
+  -d "order_amount=100.00" \
+  -d "order_currency=SAR" \
+  -d "order_description=Test Order" \
+  -d "card_number=5123445000000008" \
+  -d "card_exp_month=01" \
+  -d "card_exp_year=2039" \
+  -d "card_cvv2=100" \
+  -d "payer_first_name=John" \
+  -d "payer_last_name=Doe" \
+  -d "payer_address=123 Main St" \
+  -d "payer_country=SA" \
+  -d "payer_city=Riyadh" \
+  -d "payer_zip=12345" \
+  -d "payer_email=john.doe@example.com" \
+  -d "payer_phone=+966500000000" \
+  -d "payer_ip=192.168.1.1" \
+  -d "term_url_3ds=https://yourapp.com/3ds-callback" \
+  -d "hash=CALCULATED_HASH" \
+  -d "req_token=N"
+```
+
+#### Response Structure
+
+**Success Response** (`EdfaPgSaleSuccess`):
+```json
+{
+  "action": "SALE",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "trans_date": "2024-01-15 10:30:45",
+  "descriptor": "Merchant Name",
+  "amount": "100.00",
+  "currency": "SAR"
+}
+```
+
+**Decline Response** (`EdfaPgSaleDecline`):
+```json
+{
+  "action": "SALE",
+  "result": "DECLINED",
+  "status": "DECLINED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "trans_date": "2024-01-15 10:30:45",
+  "decline_reason": "Insufficient funds"
+}
+```
+
+**3D Secure Response** (`EdfaPgSale3ds`):
+```json
+{
+  "action": "SALE",
+  "result": "3DS",
+  "status": "3DS",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "redirect_url": "https://3ds-server.com/authenticate",
+  "redirect_params": {
+    "PaReq": "encoded-pareq",
+    "MD": "merchant-data",
+    "TermUrl": "https://yourapp.com/3ds-callback"
+  },
+  "redirect_method": "POST"
+}
+```
+
+**Recurring Response** (`EdfaPgSaleRecurring`):
+```json
+{
+  "action": "SALE",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "recurring_token": "recurring-token-string",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id"
+}
+```
+
+#### iOS Usage Example
+
+```swift
+let saleAdapter = EdfaPgSaleAdapter()
+
+let order = EdfaPgSaleOrder(
+    id: UUID().uuidString,
+    description: "Test Order",
+    currency: "SAR",
+    amount: 100.00
+)
+
+let card = EdfaPgCard(
+    number: "5123445000000008",
+    expireMonth: 01,
+    expireYear: 2039,
+    cvv: "100"
+)
+
+let payer = EdfaPgPayer(
+    firstName: "John",
+    lastName: "Doe",
+    address: "123 Main St",
+    country: "SA",
+    city: "Riyadh",
+    zip: "12345",
+    email: "john.doe@example.com",
+    phone: "+966500000000",
+    ip: "192.168.1.1"
+)
+
+saleAdapter.execute(
+    order: order,
+    card: card,
+    payer: payer,
+    termUrl3ds: "https://yourapp.com/3ds-callback",
+    auth: false
+) { response in
+    switch response {
+    case .result(let result):
+        switch result {
+        case .success(let success):
+            print("Payment successful: \(success.transactionId)")
+        case .decline(let decline):
+            print("Payment declined: \(decline.declineReason)")
+        case .secure3d(let secure3d):
+            // Redirect to 3DS authentication
+            print("3DS required: \(secure3d.redirectUrl)")
+        case .recurring(let recurring):
+            print("Recurring initialized: \(recurring.recurringToken)")
+        case .redirect(let redirect):
+            print("Redirect required: \(redirect.redirectUrl)")
+        }
+    case .error(let error):
+        print("API Error: \(error)")
+    case .failure(let error):
+        print("Request Failed: \(error)")
+    }
+}
+```
+
+---
+
+### 2. CAPTURE Transaction
+
+**Purpose**: Capture funds from a previously authorized transaction (created with `auth=Y`).
+
+**Endpoint**: `{paymentUrl}` (Base URL from configuration)
+
+**Content-Type**: `application/x-www-form-urlencoded`
+
+**Adapter Class**: `EdfaPgCaptureAdapter`
+
+**Service Class**: `EdfaPgCaptureService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "CAPTURE" |
+| `client_key` | String | Yes | Merchant identifier |
+| `trans_id` | String | Yes | Original transaction ID (UUID format) |
+| `amount` | String | No | Amount to capture (partial capture). Format: XXXX.XX. Omit for full capture |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+
+#### Hash Calculation for CAPTURE
+
+```swift
+let hash = EdfaPgHashUtil.hash(
+    email: payerEmail,
+    cardNumber: cardNumber,
+    transactionId: transactionId
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(email).client_password.trans_id.strrev(substr(card_number, 0, 6).substr(card_number, -4))))`
+
+#### Sample Request (cURL)
+
+```bash
+curl -X POST https://pay.expresspay.sa/payment/post \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -d "action=CAPTURE" \
+  -d "client_key=YOUR_MERCHANT_KEY" \
+  -d "trans_id=uuid-transaction-id" \
+  -d "amount=50.00" \
+  -d "hash=CALCULATED_HASH"
+```
+
+#### Response Structure
+
+**Success Response** (`EdfaPgCaptureSuccess`):
+```json
+{
+  "action": "CAPTURE",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "trans_date": "2024-01-15 10:35:00",
+  "amount": "50.00",
+  "currency": "SAR"
+}
+```
+
+#### iOS Usage Example
+
+```swift
+let captureAdapter = EdfaPgCaptureAdapter()
+
+captureAdapter.execute(
+    transactionId: "uuid-transaction-id",
+    payerEmail: "john.doe@example.com",
+    cardNumber: "5123445000000008",
+    amount: 50.00 // Optional for partial capture
+) { response in
+    switch response {
+    case .result(let result):
+        switch result {
+        case .success(let success):
+            print("Capture successful: \(success.transactionId)")
+        }
+    case .error(let error):
+        print("API Error: \(error)")
+    case .failure(let error):
+        print("Request Failed: \(error)")
+    }
+}
+```
+
+---
+
+### 3. CREDITVOID Transaction
+
+**Purpose**: Complete REFUND or REVERSAL transactions.
+- **REVERSAL**: Cancel hold on authorized funds (AUTH transactions)
+- **REFUND**: Return funds to card (SALE/CAPTURE transactions)
+
+**Endpoint**: `{paymentUrl}` (Base URL from configuration)
+
+**Content-Type**: `application/x-www-form-urlencoded`
+
+**Adapter Class**: `EdfaPgCreditvoidAdapter`
+
+**Service Class**: `EdfaPgCreditvoidService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "CREDITVOID" |
+| `client_key` | String | Yes | Merchant identifier |
+| `trans_id` | String | Yes | Original transaction ID (UUID format) |
+| `amount` | String | No | Amount to refund. Format: XXXX.XX. Omit for full refund |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+
+#### Hash Calculation for CREDITVOID
+
+```swift
+let hash = EdfaPgHashUtil.hash(
+    email: payerEmail,
+    cardNumber: cardNumber,
+    transactionId: transactionId
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(email).client_password.trans_id.strrev(substr(card_number, 0, 6).substr(card_number, -4))))`
+
+#### Sample Request (cURL)
+
+```bash
+curl -X POST https://pay.expresspay.sa/payment/post \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -d "action=CREDITVOID" \
+  -d "client_key=YOUR_MERCHANT_KEY" \
+  -d "trans_id=uuid-transaction-id" \
+  -d "amount=100.00" \
+  -d "hash=CALCULATED_HASH"
+```
+
+#### Response Structure
+
+**Success Response** (`EdfaPgCreditvoidSuccess`):
+```json
+{
+  "action": "CREDITVOID",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-new-transaction-id",
+  "trans_date": "2024-01-15 10:40:00",
+  "amount": "100.00",
+  "currency": "SAR"
+}
+```
+
+#### iOS Usage Example
+
+```swift
+let creditvoidAdapter = EdfaPgCreditvoidAdapter()
+
+creditvoidAdapter.execute(
+    transactionId: "uuid-transaction-id",
+    payerEmail: "john.doe@example.com",
+    cardNumber: "5123445000000008",
+    amount: 100.00 // Optional for partial refund
+) { response in
+    switch response {
+    case .result(let result):
+        switch result {
+        case .success(let success):
+            print("Creditvoid successful: \(success.transactionId)")
+        }
+    case .error(let error):
+        print("API Error: \(error)")
+    case .failure(let error):
+        print("Request Failed: \(error)")
+    }
+}
+```
+
+---
+
+### 4. RECURRING_SALE Transaction
+
+**Purpose**: Create new transactions based on stored cardholder information from previous operations. Uses data from a primary transaction to create secondary transactions.
+
+**Endpoint**: `{paymentUrl}` (Base URL from configuration)
+
+**Content-Type**: `application/x-www-form-urlencoded`
+
+**Adapter Class**: `EdfaPgRecurringSaleAdapter`
+
+**Service Class**: `EdfaPgRecurringSaleService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "RECURRING_SALE" |
+| `client_key` | String | Yes | Merchant identifier |
+| `order_id` | String | Yes | Unique order identifier for new transaction |
+| `order_amount` | String | Yes | Transaction amount (format: XXXX.XX) |
+| `order_description` | String | Yes | Order description |
+| `recurring_first_trans_id` | String | Yes | Primary transaction ID |
+| `recurring_token` | String | Yes | Recurring token from initial transaction |
+| `auth` | String | No | "Y" for AUTH-only, omit for SALE |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+
+#### Hash Calculation for RECURRING_SALE
+
+```swift
+let hash = EdfaPgHashUtil.hash(
+    email: payerEmail,
+    cardNumber: cardNumber
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(email).client_password.strrev(substr(card_number, 0, 6).substr(card_number, -4))))`
+
+#### Sample Request (cURL)
+
+```bash
+curl -X POST https://pay.expresspay.sa/payment/post \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -d "action=RECURRING_SALE" \
+  -d "client_key=YOUR_MERCHANT_KEY" \
+  -d "order_id=recurring-order-456" \
+  -d "order_amount=75.00" \
+  -d "order_description=Recurring Payment" \
+  -d "recurring_first_trans_id=uuid-original-trans-id" \
+  -d "recurring_token=token-string" \
+  -d "hash=CALCULATED_HASH"
+```
+
+#### Response Structure
+
+Same as SALE transaction responses (`EdfaPgSaleResult`).
+
+#### iOS Usage Example
+
+```swift
+let recurringSaleAdapter = EdfaPgRecurringSaleAdapter()
+
+let order = EdfaPgOrder(
+    id: "recurring-order-456",
+    amount: 75.00,
+    description: "Recurring Payment"
+)
+
+let options = EdfaPgRecurringOptions(
+    firstTransactionId: "uuid-original-trans-id",
+    token: "token-string"
+)
+
+recurringSaleAdapter.execute(
+    order: order,
+    options: options,
+    payerEmail: "john.doe@example.com",
+    cardNumber: "5123445000000008",
+    auth: false
+) { response in
+    switch response {
+    case .result(let result):
+        switch result {
+        case .success(let success):
+            print("Recurring payment successful: \(success.transactionId)")
+        case .decline(let decline):
+            print("Recurring payment declined: \(decline.declineReason)")
+        case .secure3d(let secure3d):
+            print("3DS required: \(secure3d.redirectUrl)")
+        case .recurring, .redirect:
+            break
+        }
+    case .error(let error):
+        print("API Error: \(error)")
+    case .failure(let error):
+        print("Request Failed: \(error)")
+    }
+}
+```
+
+---
+
+### 5. GET_TRANS_STATUS
+
+**Purpose**: Retrieve the current status of a transaction from the Payment Platform.
+
+**Endpoint**: `{paymentUrl}` (Base URL from configuration)
+
+**Content-Type**: `application/x-www-form-urlencoded`
+
+**Adapter Class**: `EdfaPgGetTransactionStatusAdapter`
+
+**Service Class**: `EdfaPgGetTransactionStatusService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "GET_TRANS_STATUS" |
+| `client_key` | String | Yes | Merchant identifier |
+| `trans_id` | String | Yes | Transaction ID to query (UUID format) |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+
+#### Hash Calculation for GET_TRANS_STATUS
+
+```swift
+let hash = EdfaPgHashUtil.hash(
+    email: payerEmail,
+    cardNumber: cardNumber,
+    transactionId: transactionId
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(email).client_password.trans_id.strrev(substr(card_number, 0, 6).substr(card_number, -4))))`
+
+#### Sample Request (cURL)
+
+```bash
+curl -X POST https://pay.expresspay.sa/payment/post \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -d "action=GET_TRANS_STATUS" \
+  -d "client_key=YOUR_MERCHANT_KEY" \
+  -d "trans_id=uuid-transaction-id" \
+  -d "hash=CALCULATED_HASH"
+```
+
+#### Response Structure
+
+**Success Response** (`EdfaPgGetTransactionStatusSuccess`):
+```json
+{
+  "action": "GET_TRANS_STATUS",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "trans_date": "2024-01-15 10:30:45",
+  "amount": "100.00",
+  "currency": "SAR"
+}
+```
+
+**Possible Status Values**:
+- `PENDING` - Transaction is being processed
+- `SETTLED` - Transaction completed successfully
+- `DECLINED` - Transaction was declined
+- `REFUNDED` - Transaction was refunded
+- `REVERSED` - Transaction was reversed
+- `3DS` - Awaiting 3D Secure authentication
+
+#### iOS Usage Example
+
+```swift
+let statusAdapter = EdfaPgGetTransactionStatusAdapter()
+
+statusAdapter.execute(
+    transactionId: "uuid-transaction-id",
+    payerEmail: "john.doe@example.com",
+    cardNumber: "5123445000000008"
+) { response in
+    switch response {
+    case .result(let result):
+        switch result {
+        case .success(let success):
+            print("Transaction status: \(success.status)")
+            print("Transaction ID: \(success.transactionId)")
+        }
+    case .error(let error):
+        print("API Error: \(error)")
+    case .failure(let error):
+        print("Request Failed: \(error)")
+    }
+}
+```
+
+---
+
+### 6. GET_TRANS_DETAILS
+
+**Purpose**: Retrieve complete transaction history and details for a specific order.
+
+**Endpoint**: `{paymentUrl}` (Base URL from configuration)
+
+**Content-Type**: `application/x-www-form-urlencoded`
+
+**Adapter Class**: `EdfaPgGetTransactionDetailsAdapter`
+
+**Service Class**: `EdfaPgGetTransactionDetailsService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "GET_TRANS_DETAILS" |
+| `client_key` | String | Yes | Merchant identifier |
+| `trans_id` | String | Yes | Transaction ID to query (UUID format) |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+
+#### Hash Calculation for GET_TRANS_DETAILS
+
+```swift
+let hash = EdfaPgHashUtil.hash(
+    email: payerEmail,
+    cardNumber: cardNumber,
+    transactionId: transactionId
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(email).client_password.trans_id.strrev(substr(card_number, 0, 6).substr(card_number, -4))))`
+
+#### Sample Request (cURL)
+
+```bash
+curl -X POST https://pay.expresspay.sa/payment/post \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -d "action=GET_TRANS_DETAILS" \
+  -d "client_key=YOUR_MERCHANT_KEY" \
+  -d "trans_id=uuid-transaction-id" \
+  -d "hash=CALCULATED_HASH"
+```
+
+#### Response Structure
+
+**Success Response** (`EdfaPgGetTransactionDetailsSuccess`):
+```json
+{
+  "action": "GET_TRANS_DETAILS",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "trans_date": "2024-01-15 10:30:45",
+  "amount": "100.00",
+  "currency": "SAR",
+  "transactions": [
+    {
+      "trans_id": "uuid-transaction-id",
+      "type": "SALE",
+      "status": "SETTLED",
+      "amount": "100.00",
+      "currency": "SAR",
+      "date": "2024-01-15 10:30:45"
+    },
+    {
+      "trans_id": "uuid-refund-id",
+      "type": "REFUND",
+      "status": "SETTLED",
+      "amount": "50.00",
+      "currency": "SAR",
+      "date": "2024-01-15 11:00:00"
+    }
+  ]
+}
+```
+
+#### iOS Usage Example
+
+```swift
+let detailsAdapter = EdfaPgGetTransactionDetailsAdapter()
+
+detailsAdapter.execute(
+    transactionId: "uuid-transaction-id",
+    payerEmail: "john.doe@example.com",
+    cardNumber: "5123445000000008"
+) { response in
+    switch response {
+    case .result(let result):
+        switch result {
+        case .success(let success):
+            print("Order ID: \(success.orderId)")
+            print("Transaction count: \(success.transactions?.count ?? 0)")
+            success.transactions?.forEach { transaction in
+                print("- \(transaction.type): \(transaction.amount) \(transaction.currency)")
+            }
+        }
+    case .error(let error):
+        print("API Error: \(error)")
+    case .failure(let error):
+        print("Request Failed: \(error)")
+    }
+}
+```
+
+---
+
+### 7. Apple Pay Virtual Sale
+
+**Purpose**: Process Apple Pay payment using tokenized payment data from PassKit.
+
+**Endpoint**: `{baseUrl}/applepay/orders/s2s/sale`
+
+Note: The base URL is derived from the payment URL by removing "/payment/post"
+
+Example: If `paymentUrl` = `https://pay.expresspay.sa/payment/post`
+Then Apple Pay endpoint = `https://pay.expresspay.sa/applepay/orders/s2s/sale`
+
+**Content-Type**: `multipart/form-data; boundary=boundary-edfapay-pg-formdata`
+
+**Adapter Class**: `EdfaPgVirtualSaleAdapter`
+
+**Service Class**: `EdfaPgVirtualSaleService`
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | String | Yes | Always "SALE" |
+| `client_key` | String | Yes | Merchant identifier |
+| `order_id` | String | Yes | Unique order identifier |
+| `order_amount` | String | Yes | Transaction amount (format: XXXX.XX) |
+| `order_currency` | String | Yes | Currency code (e.g., "SAR") |
+| `order_description` | String | Yes | Order description |
+| `payer_first_name` | String | Yes | Payer's first name |
+| `payer_last_name` | String | Yes | Payer's last name |
+| `payer_middle_name` | String | No | Payer's middle name |
+| `payer_birth_date` | String | No | Payer's birth date |
+| `payer_address` | String | Yes | Payer's address |
+| `payer_address2` | String | No | Additional address line |
+| `payer_country` | String | Yes | Payer's country code |
+| `payer_state` | String | No | Payer's state/region |
+| `payer_city` | String | Yes | Payer's city |
+| `payer_zip` | String | Yes | Payer's ZIP/postal code |
+| `payer_email` | String | Yes | Payer's email |
+| `payer_phone` | String | Yes | Payer's phone number |
+| `payer_ip` | String | Yes | Payer's IP address |
+| `brand` | String | Yes | Always "applepay" |
+| `identifier` | String | Yes | Apple Pay transaction identifier |
+| `return_url` | String | Yes | Return URL after processing |
+| `parameters` | String | Yes | JSON string containing Apple Pay payment token |
+| `hash` | String | Yes | Security hash (see Hash Calculation) |
+
+#### Hash Calculation for Apple Pay
+
+```swift
+let hash = EdfaPgHashUtil.hashApplePayVirtual(
+    identifier: applePayTransactionIdentifier,
+    number: order.id,
+    amount: order.formatedAmountString(),
+    currency: order.currency
+)
+```
+
+**Formula**: `md5(strtoupper(strrev(identifier).client_password.number.amount.currency))`
+
+#### Payment Token Structure
+
+The `parameters` field contains a JSON string with the following structure:
+
+```json
+{
+  "paymentData": {
+    "version": "EC_v1",
+    "data": "encrypted-payment-data",
+    "signature": "signature-string",
+    "header": {
+      "ephemeralPublicKey": "key-string",
+      "publicKeyHash": "hash-string",
+      "transactionId": "transaction-id"
+    }
+  },
+  "paymentMethod": {
+    "displayName": "Visa 1234",
+    "network": "Visa",
+    "type": "debit"
+  },
+  "transactionIdentifier": "unique-transaction-id"
+}
+```
+
+#### Sample Request (cURL with multipart)
+
+```bash
+curl -X POST https://pay.expresspay.sa/applepay/orders/s2s/sale \
+  -H "Content-Type: multipart/form-data; boundary=boundary-edfapay-pg-formdata" \
+  -H "X-User-Agent: ios" \
+  -H "Accept: application/json" \
+  -F "action=SALE" \
+  -F "client_key=YOUR_MERCHANT_KEY" \
+  -F "order_id=order-12345" \
+  -F "order_amount=100.00" \
+  -F "order_currency=SAR" \
+  -F "order_description=Apple Pay Order" \
+  -F "payer_first_name=John" \
+  -F "payer_last_name=Doe" \
+  -F "payer_email=john.doe@example.com" \
+  -F "payer_phone=+966500000000" \
+  -F "payer_address=123 Main St" \
+  -F "payer_country=SA" \
+  -F "payer_city=Riyadh" \
+  -F "payer_zip=12345" \
+  -F "payer_ip=192.168.1.1" \
+  -F "brand=applepay" \
+  -F "identifier=apple-pay-transaction-id" \
+  -F "return_url=https://yourapp.com/callback" \
+  -F "parameters={\"paymentData\":{...},\"paymentMethod\":{...}}" \
+  -F "hash=CALCULATED_HASH"
+```
+
+#### Response Structure
+
+**Success Response** (`EdfaPgSaleVirtualTransaction`):
+```json
+{
+  "action": "SALE",
+  "result": "SUCCESS",
+  "status": "SETTLED",
+  "order_id": "order-12345",
+  "trans_id": "uuid-transaction-id",
+  "trans_date": "2024-01-15 10:30:45",
+  "amount": "100.00",
+  "currency": "SAR",
+  "descriptor": "Merchant Name"
+}
+```
+
+#### iOS Usage Example
+
+See [APPLE_PAY_DOCUMENTATION.md](./APPLE_PAY_DOCUMENTATION.md) for complete Apple Pay integration guide.
+
+---
+
+## Response Structures
+
+### Common Response Fields
+
+All successful responses include:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `action` | String | The action that was performed |
+| `result` | String | "SUCCESS", "DECLINED", "ERROR", "3DS", "REDIRECT" |
+| `status` | String | Current transaction status |
+| `order_id` | String | Merchant's order identifier |
+| `trans_id` | String | Platform transaction identifier (UUID) |
+| `trans_date` | String | Transaction timestamp |
+| `amount` | String | Transaction amount |
+| `currency` | String | Currency code |
+
+### Success Result (`result: "SUCCESS"`)
+
+Additional fields:
+- `descriptor` - Merchant descriptor on customer's statement
+- `recurring_token` - Token for recurring payments (if applicable)
+
+### Decline Result (`result: "DECLINED"`)
+
+Additional fields:
+- `decline_reason` - Human-readable decline reason
+
+### 3D Secure Result (`result: "3DS"`)
+
+Additional fields:
+- `redirect_url` - URL for 3DS authentication
+- `redirect_params` - Parameters to send to redirect URL
+- `redirect_method` - HTTP method ("POST" or "GET")
+
+### Redirect Result (`result: "REDIRECT"`)
+
+Additional fields:
+- `redirect_url` - URL to redirect the customer
+- `redirect_params` - Parameters for the redirect
+- `redirect_method` - HTTP method
+
+---
+
+## Error Handling
+
+### Error Response Structure
+
+When an error occurs, the API returns an `EdfaPgError` object:
+
+```json
+{
+  "result": "ERROR",
+  "error_code": 1001,
+  "error_message": "Invalid card number",
+  "errors": {
+    "card_number": ["Card number is invalid"]
+  }
+}
+```
+
+### Common Error Codes
+
+| Code | Description |
+|------|-------------|
+| 1001 | Invalid card number |
+| 1002 | Card expired |
+| 1003 | Invalid CVV |
+| 1004 | Insufficient funds |
+| 1005 | Invalid merchant credentials |
+| 1006 | Invalid hash |
+| 1007 | Duplicate order ID |
+| 2001 | Transaction not found |
+| 3001 | System error |
+
+### Handling Errors in iOS
+
+```swift
+switch response {
+case .result(let result):
+    // Handle successful response
+    break
+    
+case .error(let error):
+    // API returned an error
+    print("Error code: \(error.errorCode)")
+    print("Error message: \(error.errorMessage)")
+    if let errors = error.errors {
+        for (field, messages) in errors {
+            print("\(field): \(messages.joined(separator: ", "))")
+        }
+    }
+    
+case .failure(let error):
+    // Network or decoding error
+    print("Request failed: \(error.localizedDescription)")
+}
+```
+
+---
+
+## Hash Calculation
+
+Hash generation is crucial for request security. The SDK provides utilities in `EdfaPgHashUtil`:
+
+### Hash Formula Patterns
+
+1. **For SALE and RECURRING_SALE**:
+   ```
+   md5(
+     strtoupper(
+       strrev(email) . 
+       client_password . 
+       strrev(substr(card_number, 0, 6) . substr(card_number, -4))
+     )
+   )
+   ```
+
+2. **For CAPTURE, CREDITVOID, GET_TRANS_STATUS, GET_TRANS_DETAILS**:
+   ```
+   md5(
+     strtoupper(
+       strrev(email) . 
+       client_password . 
+       trans_id . 
+       strrev(substr(card_number, 0, 6) . substr(card_number, -4))
+     )
+   )
+   ```
+
+3. **For Apple Pay Virtual Sale**:
+   ```
+   md5(
+     strtoupper(
+       strrev(identifier) . 
+       client_password . 
+       number . 
+       amount . 
+       currency
+     )
+   )
+   ```
+
+### Hash Calculation Examples
+
+**Example 1: SALE Hash**
+```swift
+// Given:
+let email = "john.doe@example.com"
+let clientPassword = "merchant-password-123"
+let cardNumber = "5123445000000008"
+
+// Step 1: Extract card parts
+let cardFirst6 = "512344"
+let cardLast4 = "0008"
+let cardPart = cardFirst6 + cardLast4  // "5123440008"
+
+// Step 2: Reverse strings
+let emailRev = String(email.reversed())  // "moc.elpmaxe@eod.nhoj"
+let cardPartRev = String(cardPart.reversed())  // "8004431215"
+
+// Step 3: Concatenate
+let combined = emailRev + clientPassword + cardPartRev
+
+// Step 4: Uppercase
+let upper = combined.uppercased()
+
+// Step 5: MD5
+let hash = md5(upper)
+```
+
+**Example 2: Apple Pay Hash**
+```swift
+// Given:
+let identifier = "apple-pay-trans-12345"
+let clientPassword = "merchant-password-123"
+let orderNumber = "order-12345"
+let amount = "100.00"
+let currency = "SAR"
+
+// Step 1: Reverse identifier
+let identifierRev = String(identifier.reversed())  // "54321-snart-yap-elppa"
+
+// Step 2: Concatenate
+let combined = identifierRev + clientPassword + orderNumber + amount + currency
+
+// Step 3: Uppercase
+let upper = combined.uppercased()
+
+// Step 4: MD5
+let hash = md5(upper)
+```
+
+### Using SDK Hash Utilities
+
+The SDK provides convenient methods:
+
+```swift
+// For regular card transactions
+let hash = EdfaPgHashUtil.hash(
+    email: "john.doe@example.com",
+    cardNumber: "5123445000000008"
+)
+
+// For transactions with trans_id
+let hash = EdfaPgHashUtil.hash(
+    email: "john.doe@example.com",
+    cardNumber: "5123445000000008",
+    transactionId: "uuid-trans-id"
+)
+
+// For Apple Pay
+let hash = EdfaPgHashUtil.hashApplePayVirtual(
+    identifier: "apple-pay-trans-id",
+    number: "order-12345",
+    amount: "100.00",
+    currency: "SAR"
+)
+```
+
+---
+
+## Best Practices
+
+1. **Always use HTTPS** - Never send payment data over unsecured connections
+
+2. **Validate data before sending** - Ensure all required fields are populated
+
+3. **Handle 3D Secure properly** - Implement redirect handling for 3DS authentication
+
+4. **Store recurring tokens securely** - Use iOS Keychain for sensitive data
+
+5. **Implement proper error handling** - Show user-friendly messages for common errors
+
+6. **Test with test cards** - Use provided test card numbers during development
+
+7. **Log requests in debug mode** - The SDK provides built-in logging for debugging
+
+8. **Monitor transaction status** - Use GET_TRANS_STATUS for long-running transactions
+
+9. **Implement timeouts** - Handle network timeouts gracefully
+
+10. **Follow PCI compliance** - Never log or store full card numbers in production
+
+---
+
+## Debugging
+
+### Enable Debug Logging
+
+The SDK includes comprehensive request/response logging:
+
+```swift
+// Debug logging is controlled by ENABLE_DEBUG flag
+// In EdfaPgRestApiClient, set printRequestInfo = true
+
+let apiClient = EdfaPgRestApiClient()
+apiClient.printRequestInfo = true  // Enables detailed logging
+```
+
+### Debug Output Format
+
+```
+-------------------------------------------------------------
+SUCCESS 200
+
+POST
+REQUEST:
+
+  URL: 
+    https://pay.expresspay.sa/payment/post
+  HEADERS: 
+    {
+      "Accept" : "application/json",
+      "Content-Type" : "application/x-www-form-urlencoded",
+      "X-User-Agent" : "ios"
+    }
+  PARAMETERS:
+    action: SALE
+    client_key: YOUR_MERCHANT_KEY
+    order_id: order-12345
+    ...
+
+RESPONSE:
+  {
+    "action" : "SALE",
+    "result" : "SUCCESS",
+    "status" : "SETTLED",
+    ...
+  }
+-------------------------------------------------------------
+```
+
+---
+
+## Test Cards
+
+Use these test card numbers during development:
+
+| Card Number | Type | 3DS | Expected Result |
+|-------------|------|-----|-----------------|
+| 5123445000000008 | Mastercard | No | Success |
+| 4111111111111111 | Visa | No | Success |
+| 4000000000000002 | Visa | Yes | 3DS Required |
+| 4000000000000010 | Visa | No | Declined |
+
+**Test Card Details:**
+- Expiry: Any future date (e.g., 01/2039)
+- CVV: Any 3 digits (e.g., 100)
+
+---
+
+## Support
+
+For additional support:
+
+- Email: [support@edfapay.com](mailto:support@edfapay.com)
+- Phone: [+966920033633](tel:+966920033633)
+- Website: [https://edfapay.com](https://edfapay.com)
+
+---
+
+*Last Updated: January 2025*
+*SDK Version: Compatible with EdfaPgSdk v1.x*

--- a/HTTP_API_DOCUMENTATION.md
+++ b/HTTP_API_DOCUMENTATION.md
@@ -826,7 +826,7 @@ let hash = EdfaPgHashUtil.hashApplePayVirtual(
 )
 ```
 
-**Formula**: `md5(strtoupper(strrev(identifier).client_password.number.amount.currency))`
+**Formula**: `md5(strtoupper(strrev(identifier.number.amount.currency.client_password)))`
 
 #### Payment Token Structure
 
@@ -1039,11 +1039,13 @@ Hash generation is crucial for request security. The SDK provides utilities in `
    ```
    md5(
      strtoupper(
-       strrev(identifier) . 
-       client_password . 
-       number . 
-       amount . 
-       currency
+       strrev(
+         identifier . 
+         number . 
+         amount . 
+         currency . 
+         client_password
+       )
      )
    )
    ```
@@ -1080,19 +1082,19 @@ let hash = md5(upper)
 ```swift
 // Given:
 let identifier = "apple-pay-trans-12345"
-let clientPassword = "merchant-password-123"
 let orderNumber = "order-12345"
 let amount = "100.00"
 let currency = "SAR"
+let clientPassword = "merchant-password-123"
 
-// Step 1: Reverse identifier
-let identifierRev = String(identifier.reversed())  // "54321-snart-yap-elppa"
+// Step 1: Concatenate all values
+let combined = identifier + orderNumber + amount + currency + clientPassword
 
-// Step 2: Concatenate
-let combined = identifierRev + clientPassword + orderNumber + amount + currency
+// Step 2: Reverse the entire combined string
+let reversed = String(combined.reversed())
 
 // Step 3: Uppercase
-let upper = combined.uppercased()
+let upper = reversed.uppercased()
 
 // Step 4: MD5
 let hash = md5(upper)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ The main aspects of the EdfaPg iOS SDK:
 
 To get used to the SDK, download a [sample app](https://github.com/edfapay/edfa-pg-ios-sdk-sample ).
 
+## Documentation
+
+For detailed documentation, please refer to:
+
+- **[HTTP API Documentation](HTTP_API_DOCUMENTATION.md)** - Complete reference for all HTTP API endpoints including:
+  - SALE, CAPTURE, CREDITVOID transactions
+  - RECURRING_SALE for subscription payments
+  - GET_TRANS_STATUS and GET_TRANS_DETAILS for transaction queries
+  - Request/response structures, parameters, and examples
+  - Security and hash calculation
+  - Error handling and debugging
+
+- **[Apple Pay Documentation](APPLE_PAY_DOCUMENTATION.md)** - Comprehensive guide for Apple Pay integration including:
+  - Prerequisites and Apple Pay configuration
+  - Step-by-step integration guide
+  - Payment flow and API structure
+  - Payment token details
+  - Code examples and best practices
+  - Testing and troubleshooting
+
 ## Setup
 
 Add to the `Podfile`:


### PR DESCRIPTION
This pull request adds a new documentation section to the `README.md` to help developers more easily find detailed guides for integrating and using the SDK. The update introduces direct links to comprehensive documentation for both the HTTP API and Apple Pay integration.

Documentation improvements:

* Added a "Documentation" section to `README.md` with links to `HTTP_API_DOCUMENTATION.md` and `APPLE_PAY_DOCUMENTATION.md`, summarizing the contents and topics covered in each guide.